### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -8,6 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js


### PR DESCRIPTION
Potential fix for [https://github.com/jacobbarssbailey/wombatmylove/security/code-scanning/2](https://github.com/jacobbarssbailey/wombatmylove/security/code-scanning/2)

In general, to fix this class of problem you add an explicit `permissions:` block either at the workflow root (applies to all jobs) or under each job, granting only the specific scopes needed. This documents the required permissions and prevents the workflow from unintentionally inheriting broader repository defaults.

For this specific workflow (`.github/workflows/post.yml`), the `build` job needs to commit changes back to the repository using `EndBug/add-and-commit@v9`, which requires `contents: write`. The rest of the steps (checkout, setup-node, npm commands, posting to Bluesky) do not require extra GitHub API scopes. The best minimal fix is therefore to add a `permissions:` block under `jobs.build` (same indentation level as `runs-on` and `environment`) specifying `contents: write`. No other permissions (e.g., `pull-requests`, `packages`) are needed based on the snippet shown.

Concretely:
- Edit `.github/workflows/post.yml`.
- Under `jobs:`, inside the `build:` job, insert:

```yaml
    permissions:
      contents: write
```

- Place it between `environment: production` and `steps:` (or just after `runs-on` if you prefer), ensuring indentation is consistent (four spaces under `build:`).

No imports or additional methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
